### PR TITLE
Add BASIC_TEST mode to isolate display

### DIFF
--- a/ESP32_CHAT/app.cpp
+++ b/ESP32_CHAT/app.cpp
@@ -15,6 +15,7 @@ void begin() {
 
   display.init();
   initDisplay(display);
+#if !BASIC_TEST
   lvgl_ui::begin();
   initAudio();
 
@@ -23,6 +24,9 @@ void begin() {
     Serial.println("Location lookup failed. Using defaults.");
   }
   initChatGpt();
+#else
+  displayMessage("Basic display test");
+#endif
 
   state.page = Page::Weather;
   state.lastWeather = 0;
@@ -30,6 +34,7 @@ void begin() {
 }
 
 void loop() {
+#if !BASIC_TEST
   processTouch();
   processSerial();
   lvgl_ui::loop();
@@ -44,9 +49,17 @@ void loop() {
                         state.weatherCode, state.raining,
                         state.lastWeather, state.weatherFail);
   }
+#else
+  // Basic test simply keeps the message on screen
+  delay(1000);
+#endif
 }
 
 static void connectWiFi() {
+#if BASIC_TEST
+  // Skip WiFi in basic test
+  displayMessage("WiFi disabled (BASIC_TEST)");
+#else
   displayMessage("Connecting to WiFi...");
   WiFi.setSleep(false);
   WiFi.begin(WIFI_SSID, WIFI_PASS);
@@ -61,9 +74,14 @@ static void connectWiFi() {
     while (true) delay(1000);
   }
   displayMessage("WiFi connected.\nGetting weather...");
+#endif
 }
 
 static void processSerial() {
+#if BASIC_TEST
+  // Serial commands disabled in basic mode
+  return;
+#else
   if (Serial.available() == 0) return;
   String prompt = Serial.readStringUntil('\n');
   prompt.trim();
@@ -88,9 +106,14 @@ static void processSerial() {
     callChatGpt(prompt);
     lvgl_ui::showChat("");
   }
+#endif
 }
 
 static void processTouch() {
+#if BASIC_TEST
+  // Skip touch handling in basic test
+  return;
+#else
   int pos[2] = { -1, -1 };
   readTouch(pos);
   if (pos[0] < 0 || pos[1] < 0) return;
@@ -114,6 +137,7 @@ static void processTouch() {
                             state.raining, prog);
     }
   }
+#endif
 }
 
 } // namespace app

--- a/ESP32_CHAT/app.h
+++ b/ESP32_CHAT/app.h
@@ -1,4 +1,9 @@
 #pragma once
+
+// Define BASIC_TEST to disable most features and only
+// initialize the display for debugging.
+#define BASIC_TEST 1
+
 #include "display.h"
 #include "chatgpt.h"
 #include "weather.h"


### PR DESCRIPTION
## Summary
- add `BASIC_TEST` flag to disable advanced features
- gate WiFi, LVGL, ChatGPT and touch routines behind that flag
- display a simple message when running in BASIC_TEST mode

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6869a9e34a0083219e74125516a3aa3b