### PR TITLE
Add simple display mode

### DIFF
--- a/ESP32_CHAT/app.cpp
+++ b/ESP32_CHAT/app.cpp
@@ -15,6 +15,7 @@ void begin() {
 
   display.init();
   initDisplay(display);
+#if !BASIC_TEST
   lvgl_ui::begin();
   initAudio();
 
@@ -23,6 +24,9 @@ void begin() {
     Serial.println("Location lookup failed. Using defaults.");
   }
   initChatGpt();
+#else
+  displayMessage("Basic display test");
+#endif
 
   state.page = Page::Weather;
   state.lastWeather = 0;
@@ -30,6 +34,7 @@ void begin() {
 }
 
 void loop() {
+#if !BASIC_TEST
   processTouch();
   processSerial();
   lvgl_ui::loop();
@@ -44,9 +49,17 @@ void loop() {
                         state.weatherCode, state.raining,
                         state.lastWeather, state.weatherFail);
   }
+#else
+  // Basic test simply keeps the message on screen
+  delay(1000);
+#endif
 }
 
 static void connectWiFi() {
+#if BASIC_TEST
+  // Skip WiFi in basic test
+  displayMessage("WiFi disabled (BASIC_TEST)");
+#else
   displayMessage("Connecting to WiFi...");
   WiFi.setSleep(false);
   WiFi.begin(WIFI_SSID, WIFI_PASS);
@@ -61,9 +74,14 @@ static void connectWiFi() {
     while (true) delay(1000);
   }
   displayMessage("WiFi connected.\nGetting weather...");
+#endif
 }
 
 static void processSerial() {
+#if BASIC_TEST
+  // Serial commands disabled in basic mode
+  return;
+#else
   if (Serial.available() == 0) return;
   String prompt = Serial.readStringUntil('\n');
   prompt.trim();
@@ -88,9 +106,14 @@ static void processSerial() {
     callChatGpt(prompt);
     lvgl_ui::showChat("");
   }
+#endif
 }
 
 static void processTouch() {
+#if BASIC_TEST
+  // Skip touch handling in basic test
+  return;
+#else
   int pos[2] = { -1, -1 };
   readTouch(pos);
   if (pos[0] < 0 || pos[1] < 0) return;
@@ -114,6 +137,7 @@ static void processTouch() {
                             state.raining, prog);
     }
   }
+#endif
 }
 
 } // namespace app

--- a/ESP32_CHAT/app.cpp
+++ b/ESP32_CHAT/app.cpp
@@ -15,7 +15,7 @@ void begin() {
 
   display.init();
   initDisplay(display);
-#if !BASIC_TEST
+#if !DEBUG_MODE
   lvgl_ui::begin();
   initAudio();
 
@@ -34,7 +34,7 @@ void begin() {
 }
 
 void loop() {
-#if !BASIC_TEST
+#if !DEBUG_MODE
   processTouch();
   processSerial();
   lvgl_ui::loop();
@@ -56,9 +56,9 @@ void loop() {
 }
 
 static void connectWiFi() {
-#if BASIC_TEST
+#if DEBUG_MODE
   // Skip WiFi in basic test
-  displayMessage("WiFi disabled (BASIC_TEST)");
+  displayMessage("WiFi disabled (DEBUG_MODE)");
 #else
   displayMessage("Connecting to WiFi...");
   WiFi.setSleep(false);
@@ -78,7 +78,7 @@ static void connectWiFi() {
 }
 
 static void processSerial() {
-#if BASIC_TEST
+#if DEBUG_MODE
   // Serial commands disabled in basic mode
   return;
 #else
@@ -110,7 +110,7 @@ static void processSerial() {
 }
 
 static void processTouch() {
-#if BASIC_TEST
+#if DEBUG_MODE
   // Skip touch handling in basic test
   return;
 #else

--- a/ESP32_CHAT/app.h
+++ b/ESP32_CHAT/app.h
@@ -1,8 +1,8 @@
 #pragma once
 
-// Define BASIC_TEST to disable most features and only
+// Define DEBUG_MODE to disable most features and only
 // initialize the display for debugging.
-#define BASIC_TEST 1
+#define DEBUG_MODE 1
 
 #include "display.h"
 #include "chatgpt.h"
@@ -32,4 +32,3 @@ void begin();
 void loop();
 
 } // namespace app
-

--- a/ESP32_CHAT/app.h
+++ b/ESP32_CHAT/app.h
@@ -1,4 +1,9 @@
 #pragma once
+
+// Define BASIC_TEST to disable most features and only
+// initialize the display for debugging.
+#define BASIC_TEST 1
+
 #include "display.h"
 #include "chatgpt.h"
 #include "weather.h"

--- a/ESP32_CHAT/display.ino
+++ b/ESP32_CHAT/display.ino
@@ -3,6 +3,7 @@
 #include "chatgpt.h"
 #include "secrets.h"
 #include "weather.h"
+#include "app.h" // for BASIC_TEST flag
 #include "Fonts/FreeSansBold.h"
 
 /* ================================================================
@@ -19,10 +20,12 @@ static lgfx::LGFX_Sprite canvas;
 void initDisplay(DisplayGFX& d) {
   displayRef = &d;
   d.setFont(&FreeSansBold);
+#if !BASIC_TEST
   canvas.setColorDepth(16);
   canvas.setPsram(true);
   canvas.setFont(&FreeSansBold);
   canvas.createSprite(SCREEN_WIDTH, SCREEN_HEIGHT);
+#endif
 }
 
 static uint16_t rgb565(uint8_t r, uint8_t g, uint8_t b) {
@@ -181,6 +184,15 @@ void drawLoadingAnimation() {
 
 void displayMessage(String message) {
   DisplayGFX& disp = *displayRef;
+#if BASIC_TEST
+  disp.startWrite();
+  disp.fillScreen(TFT_BLACK);
+  disp.setCursor(0, 0);
+  disp.setTextSize(2);
+  disp.setTextColor(TFT_WHITE, TFT_BLACK);
+  disp.println(message);
+  disp.endWrite();
+#else
   canvas.fillScreen(TFT_BLACK);
   canvas.setCursor(0, 0);
   canvas.setTextSize(1);
@@ -188,6 +200,7 @@ void displayMessage(String message) {
   disp.startWrite();
   canvas.pushSprite(0, 0);
   disp.endWrite();
+#endif
 }
 
 void drawChatGptScreen() {

--- a/ESP32_CHAT/display.ino
+++ b/ESP32_CHAT/display.ino
@@ -3,7 +3,7 @@
 #include "chatgpt.h"
 #include "secrets.h"
 #include "weather.h"
-#include "app.h" // for BASIC_TEST flag
+#include "app.h" // for DEBUG_MODE flag
 #include "Fonts/FreeSansBold.h"
 
 /* ================================================================
@@ -20,7 +20,7 @@ static lgfx::LGFX_Sprite canvas;
 void initDisplay(DisplayGFX& d) {
   displayRef = &d;
   d.setFont(&FreeSansBold);
-#if !BASIC_TEST
+#if !DEBUG_MODE
   canvas.setColorDepth(16);
   canvas.setPsram(true);
   canvas.setFont(&FreeSansBold);
@@ -184,7 +184,7 @@ void drawLoadingAnimation() {
 
 void displayMessage(String message) {
   DisplayGFX& disp = *displayRef;
-#if BASIC_TEST
+#if DEBUG_MODE
   disp.startWrite();
   disp.fillScreen(TFT_BLACK);
   disp.setCursor(0, 0);


### PR DESCRIPTION
## Summary
- include `app.h` in `display.ino`
- skip sprite allocation while `BASIC_TEST` is enabled
- draw text directly to the screen in `displayMessage`

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6869a9e34a0083219e74125516a3aa3b