### PR TITLE
Enable debug logging and guard unallocated sprite

### DIFF
--- a/ESP32_CHAT/app.cpp
+++ b/ESP32_CHAT/app.cpp
@@ -11,26 +11,37 @@ static void processTouch();
 
 void begin() {
   Serial.begin(115200);
+  Serial.println("app: begin");
   Wire.begin(I2C_SDA, I2C_SCL);
 
+  Serial.println("app: display.init");
   display.init();
+  Serial.println("app: initDisplay");
   initDisplay(display);
 #if !DEBUG_MODE
-  lvgl_ui::begin();
+  Serial.println("app: lvgl_ui.begin");
+  if (!lvgl_ui::begin()) {
+    Serial.println("LVGL UI disabled due to init failure");
+  }
+  Serial.println("app: initAudio");
   initAudio();
 
+  Serial.println("app: connectWiFi");
   connectWiFi();
   if (!fetchLocation()) {
     Serial.println("Location lookup failed. Using defaults.");
   }
+  Serial.println("app: initChatGpt");
   initChatGpt();
 #else
+  Serial.println("app: DEBUG_MODE display test");
   displayMessage("Basic display test");
 #endif
 
   state.page = Page::Weather;
   state.lastWeather = 0;
   state.weatherFail = 0;
+  Serial.println("app: ready");
 }
 
 void loop() {

--- a/ESP32_CHAT/app.h
+++ b/ESP32_CHAT/app.h
@@ -1,8 +1,10 @@
 #pragma once
 
-// Define DEBUG_MODE to disable most features and only
-// initialize the display for debugging.
-#define DEBUG_MODE 1
+// Set DEBUG_MODE to 1 for a minimal build that only
+// initializes the display for debugging.  Set to 0 to
+// enable WiFi, weather updates, the ChatGPT client and
+// the LVGL UI.
+#define DEBUG_MODE 0
 
 #include "display.h"
 #include "chatgpt.h"

--- a/ESP32_CHAT/display.ino
+++ b/ESP32_CHAT/display.ino
@@ -16,15 +16,22 @@
 DisplayGFX display;
 static DisplayGFX* displayRef = nullptr;
 static lgfx::LGFX_Sprite canvas;
+static bool spriteReady = false;
 
 void initDisplay(DisplayGFX& d) {
   displayRef = &d;
   d.setFont(&FreeSansBold);
 #if !DEBUG_MODE
+  Serial.println("initDisplay: creating sprite");
   canvas.setColorDepth(16);
   canvas.setPsram(true);
   canvas.setFont(&FreeSansBold);
-  canvas.createSprite(SCREEN_WIDTH, SCREEN_HEIGHT);
+  if (!canvas.createSprite(SCREEN_WIDTH, SCREEN_HEIGHT)) {
+    Serial.println("Sprite allocation failed - reduce resolution or enable PSRAM");
+    spriteReady = false;
+  } else {
+    spriteReady = true;
+  }
 #endif
 }
 
@@ -116,6 +123,10 @@ static void drawHomeButton(lgfx::LGFXBase& d) {
 
 void drawWeatherScreen(float tempC, float tempMin, float tempMax, bool isRain, float progress) {
   DisplayGFX& disp = *displayRef;
+  if (!spriteReady) {
+    Serial.println("drawWeatherScreen skipped - sprite not ready");
+    return;
+  }
   canvas.fillScreen(TFT_BLACK);
 
   uint16_t bg1 = bgColorForTemp(tempC);
@@ -167,6 +178,10 @@ void drawWeatherScreen(float tempC, float tempMin, float tempMax, bool isRain, f
 
 void drawLoadingAnimation() {
   DisplayGFX& disp = *displayRef;
+  if (!spriteReady) {
+    Serial.println("drawLoadingAnimation skipped - sprite not ready");
+    return;
+  }
   canvas.fillScreen(TFT_BLACK);
   canvas.setTextSize(1);
   canvas.setCursor(10, 20);
@@ -193,6 +208,10 @@ void displayMessage(String message) {
   disp.println(message);
   disp.endWrite();
 #else
+  if (!spriteReady) {
+    Serial.println("displayMessage skipped - sprite not ready");
+    return;
+  }
   canvas.fillScreen(TFT_BLACK);
   canvas.setCursor(0, 0);
   canvas.setTextSize(1);
@@ -205,6 +224,10 @@ void displayMessage(String message) {
 
 void drawChatGptScreen() {
   DisplayGFX& disp = *displayRef;
+  if (!spriteReady) {
+    Serial.println("drawChatGptScreen skipped - sprite not ready");
+    return;
+  }
   if (millis() - getLastTypingTime() > getTypingDelay()) {
     updateLastTypingTime();
 
@@ -223,6 +246,10 @@ void drawChatGptScreen() {
 
 void drawBitmapImage(const uint8_t* bitmap, int width, int height) {
   DisplayGFX& disp = *displayRef;
+  if (!spriteReady) {
+    Serial.println("drawBitmapImage skipped - sprite not ready");
+    return;
+  }
   canvas.fillScreen(TFT_BLACK);
   int x = (SCREEN_WIDTH - width) / 2;
   int y = (SCREEN_HEIGHT - height) / 2;

--- a/ESP32_CHAT/lvgl_ui.cpp
+++ b/ESP32_CHAT/lvgl_ui.cpp
@@ -4,6 +4,7 @@
 using namespace lvgl::widget;
 
 namespace lvgl_ui {
+static bool ready = false;
 static lv_disp_draw_buf_t draw_buf;
 static lv_color_t *buf1 = nullptr;
 static lv_color_t *buf2 = nullptr;
@@ -57,12 +58,17 @@ static void createChatScreen() {
   label_chat->SetAlign(LV_ALIGN_TOP_LEFT, 10, 10);
 }
 
-void begin() {
+bool begin() {
+  Serial.println("lvgl_ui: begin");
   lv_init();
 
   uint32_t buf_size = SCREEN_WIDTH * 40;
   buf1 = (lv_color_t*)heap_caps_malloc(buf_size * sizeof(lv_color_t), MALLOC_CAP_DMA);
   buf2 = (lv_color_t*)heap_caps_malloc(buf_size * sizeof(lv_color_t), MALLOC_CAP_DMA);
+  if (!buf1 || !buf2) {
+    Serial.println("LVGL buffer allocation failed");
+    return false;
+  }
   lv_disp_draw_buf_init(&draw_buf, buf1, buf2, buf_size);
 
   lv_disp_drv_init(&disp_drv);
@@ -71,19 +77,25 @@ void begin() {
   disp_drv.flush_cb = flush_cb;
   disp_drv.draw_buf = &draw_buf;
   lv_disp_drv_register(&disp_drv);
+  Serial.println("lvgl_ui: display driver registered");
 
   lv_indev_drv_init(&indev_drv);
   indev_drv.type = LV_INDEV_TYPE_POINTER;
   indev_drv.read_cb = touch_cb;
   lv_indev_drv_register(&indev_drv);
+  Serial.println("lvgl_ui: input driver registered");
 
   createWeatherScreen();
   createChatScreen();
 
   lv_scr_load(scr_weather);
+  ready = true;
+  Serial.println("lvgl_ui: ready");
+  return true;
 }
 
 void loop() {
+  if (!ready) return;
   lv_timer_handler();
 }
 
@@ -92,10 +104,11 @@ void updateWeather(float tempC, float tempMin, float tempMax, bool isRain,
   label_temp->SetText("%.1f C (%.0f/%.0f)", tempC, tempMin, tempMax);
   progress_bar->SetValue((int)(progress * 100), LV_ANIM_OFF);
 
-  lv_scr_load(scr_weather);
+  if (ready) lv_scr_load(scr_weather);
 }
 
 void showChat(const String &text) {
+  if (!ready) return;
   label_chat->SetText("%s", text.c_str());
   lv_scr_load(scr_chat);
 }

--- a/ESP32_CHAT/lvgl_ui.h
+++ b/ESP32_CHAT/lvgl_ui.h
@@ -11,7 +11,9 @@
 #include "touch.h"
 
 namespace lvgl_ui {
-  void begin();
+  // Initialize LVGL. Returns false if required buffers could not
+  // be allocated (e.g. PSRAM disabled or not enough heap).
+  bool begin();
   void loop();
   void updateWeather(float tempC, float tempMin, float tempMax, bool isRain,
                      float progress);

--- a/README.md
+++ b/README.md
@@ -135,6 +135,9 @@ ChatESP should eventually be able to support:
    #define DEFAULT_PLACE_LNG  "18.4"
    ```
 4. Select your board and COM port in Arduino IDE, then compile and upload.
+5. Ensure `DEBUG_MODE` in `ESP32_CHAT/app.h` is set to `0` to enable all features. Set it to `1` for a minimal display-only build used for debugging.
+6. When building for the full UI, enable **PSRAM** in the board menu.  Lack of
+   PSRAM can cause LVGL to crash on startup due to buffer allocation failure.
 
 ---
 


### PR DESCRIPTION
## Summary
- add debug logs in `app::begin()` for each init step
- guard sprite operations behind a `spriteReady` flag to avoid crashes
- log LVGL initialization progress

## Testing
- `make test` *(fails: No rule to make target 'test')*


------
https://chatgpt.com/codex/tasks/task_e_6869b30ef218832193cdcbf33e6df9f9