### PR TITLE
Switch display driver to TFT_eSPI

### DIFF
--- a/ESP32_CHAT/app.cpp
+++ b/ESP32_CHAT/app.cpp
@@ -15,9 +15,13 @@ void begin() {
   Wire.begin(I2C_SDA, I2C_SCL);
 
   Serial.println("app: display.init");
+#ifdef USE_TFT_ESPI
+  display.begin();
+#else
   display.init();
+#endif
   Serial.println("app: initDisplay");
-  initDisplay(display);
+  initDisplay();
 #if !DEBUG_MODE
   Serial.println("app: lvgl_ui.begin");
   if (!lvgl_ui::begin()) {

--- a/ESP32_CHAT/display.h
+++ b/ESP32_CHAT/display.h
@@ -1,11 +1,27 @@
 #pragma once
-#define LGFX_MAKERFABS_TOUCHCAMERA
-#ifndef LGFX_USE_V1
-#define LGFX_USE_V1
-#endif
-#include <LovyanGFX.hpp>
 #include "makerfabs_pin.h"
-#include "DisplayGFX.h"
+#ifndef USE_TFT_ESPI
+#define USE_TFT_ESPI
+#endif
+
+/*
+ * Select the underlying display driver. By default the code used the
+ * LovyanGFX based `DisplayGFX` class. The Makerfabs demo uses the
+ * `TFT_eSPI` library so a compile time flag can switch between the two
+ * implementations. Defining `USE_TFT_ESPI` will use the TFT_eSPI
+ * driver instead of LovyanGFX.
+ */
+
+#ifdef USE_TFT_ESPI
+#  include <TFT_eSPI.h>
+#else
+#  define LGFX_MAKERFABS_TOUCHCAMERA
+#  ifndef LGFX_USE_V1
+#    define LGFX_USE_V1
+#  endif
+#  include <LovyanGFX.hpp>
+#  include "DisplayGFX.h"
+#endif
 
 // Display driver configured for the Makerfabs 3.5" ILI9488 touch screen.
 // The concrete class is named `DisplayGFX` and exposed project‑wide.
@@ -18,9 +34,13 @@
  * ========================================= */
 
 
+#ifdef USE_TFT_ESPI
+extern TFT_eSPI display;
+#else
 extern DisplayGFX display;
+#endif
 
-void initDisplay(DisplayGFX& d);
+void initDisplay();
 void drawWeatherScreen(float tempC, float tempMin, float tempMax, bool isRain, float progress);
 void drawLoadingAnimation();
 void displayMessage(String message);

--- a/ESP32_CHAT/display.ino
+++ b/ESP32_CHAT/display.ino
@@ -13,14 +13,27 @@
  * different UI screens and graphics
  * ================================================================ */
 
+#ifdef USE_TFT_ESPI
+TFT_eSPI display = TFT_eSPI();
+static TFT_eSprite canvas = TFT_eSprite(&display);
+using gfx_base = TFT_eSPI;
+#else
 DisplayGFX display;
 static DisplayGFX* displayRef = nullptr;
 static lgfx::LGFX_Sprite canvas;
+using gfx_base = lgfx::LGFXBase;
+#endif
 static bool spriteReady = false;
-
-void initDisplay(DisplayGFX& d) {
-  displayRef = &d;
-  d.setFont(&FreeSansBold);
+#ifdef USE_TFT_ESPI
+void initDisplay() {
+  display.begin();
+  display.setRotation(3);
+  display.setFont(&FreeSansBold);
+#else
+void initDisplay() {
+  displayRef = &display;
+  display.setFont(&FreeSansBold);
+#endif
 #if !DEBUG_MODE
   Serial.println("initDisplay: creating sprite");
   canvas.setColorDepth(16);
@@ -34,6 +47,7 @@ void initDisplay(DisplayGFX& d) {
   }
 #endif
 }
+#endif // USE_TFT_ESPI
 
 static uint16_t rgb565(uint8_t r, uint8_t g, uint8_t b) {
   return ((r & 0xF8) << 8) | ((g & 0xFC) << 3) | (b >> 3);
@@ -47,7 +61,7 @@ static uint16_t bgColorForTemp(float t) {
   return rgb565(200, 0, 0);
 }
 
-static void fillGradient(lgfx::LGFXBase& d, uint16_t c1, uint16_t c2) {
+static void fillGradient(gfx_base& d, uint16_t c1, uint16_t c2) {
   uint8_t sr = ((c1 >> 11) & 0x1F) << 3;
   uint8_t sg = ((c1 >> 5) & 0x3F) << 2;
   uint8_t sb = (c1 & 0x1F) << 3;
@@ -69,7 +83,7 @@ static void fillGradient(lgfx::LGFXBase& d, uint16_t c1, uint16_t c2) {
 }
 
 static float sunAngle = 0.0f;
-static void drawSunIcon(lgfx::LGFXBase& d, int x, int y) {
+static void drawSunIcon(gfx_base& d, int x, int y) {
   uint16_t yellow = rgb565(255, 200, 0);
   uint16_t orange = rgb565(255, 150, 0);
   int cx = x + 25;
@@ -86,7 +100,7 @@ static void drawSunIcon(lgfx::LGFXBase& d, int x, int y) {
   sunAngle += 0.02f;
 }
 
-static void drawRainIcon(lgfx::LGFXBase& d, int x, int y) {
+static void drawRainIcon(gfx_base& d, int x, int y) {
   uint16_t grey = rgb565(180, 180, 180);
   int cx = x + 25;
   int cy = y + 20;
@@ -106,14 +120,14 @@ static void drawRainIcon(lgfx::LGFXBase& d, int x, int y) {
 static const uint16_t COLOR_BG = rgb565(52, 53, 65);
 static const uint16_t COLOR_ACCENT = rgb565(16, 163, 127);
 
-static void drawAssistantButton(lgfx::LGFXBase& d) {
+static void drawAssistantButton(gfx_base& d) {
   int s = 50; int y = SCREEN_HEIGHT - s - 8; int x = SCREEN_WIDTH - s - 8;
   d.fillRoundRect(x, y, s, s, 8, COLOR_BG);
   d.drawCircle(x + s / 2, y + s / 2 - 4, 12, COLOR_ACCENT);
   d.fillRect(x + s / 2 - 8, y + s / 2 + 8, 16, 4, COLOR_ACCENT);
 }
 
-static void drawHomeButton(lgfx::LGFXBase& d) {
+static void drawHomeButton(gfx_base& d) {
   int s = 50; int y = SCREEN_HEIGHT - s - 8; int x = 8;
   d.fillRoundRect(x, y, s, s, 8, COLOR_BG);
   int cx = x + s / 2;
@@ -122,7 +136,11 @@ static void drawHomeButton(lgfx::LGFXBase& d) {
 }
 
 void drawWeatherScreen(float tempC, float tempMin, float tempMax, bool isRain, float progress) {
-  DisplayGFX& disp = *displayRef;
+#ifdef USE_TFT_ESPI
+  gfx_base& disp = display;
+#else
+  gfx_base& disp = *displayRef;
+#endif
   if (!spriteReady) {
     Serial.println("drawWeatherScreen skipped - sprite not ready");
     return;
@@ -177,7 +195,11 @@ void drawWeatherScreen(float tempC, float tempMin, float tempMax, bool isRain, f
 }
 
 void drawLoadingAnimation() {
-  DisplayGFX& disp = *displayRef;
+#ifdef USE_TFT_ESPI
+  gfx_base& disp = display;
+#else
+  gfx_base& disp = *displayRef;
+#endif
   if (!spriteReady) {
     Serial.println("drawLoadingAnimation skipped - sprite not ready");
     return;
@@ -198,7 +220,11 @@ void drawLoadingAnimation() {
 }
 
 void displayMessage(String message) {
-  DisplayGFX& disp = *displayRef;
+#ifdef USE_TFT_ESPI
+  gfx_base& disp = display;
+#else
+  gfx_base& disp = *displayRef;
+#endif
 #if DEBUG_MODE
   disp.startWrite();
   disp.fillScreen(TFT_BLACK);
@@ -223,7 +249,11 @@ void displayMessage(String message) {
 }
 
 void drawChatGptScreen() {
-  DisplayGFX& disp = *displayRef;
+#ifdef USE_TFT_ESPI
+  gfx_base& disp = display;
+#else
+  gfx_base& disp = *displayRef;
+#endif
   if (!spriteReady) {
     Serial.println("drawChatGptScreen skipped - sprite not ready");
     return;
@@ -245,7 +275,11 @@ void drawChatGptScreen() {
 }
 
 void drawBitmapImage(const uint8_t* bitmap, int width, int height) {
-  DisplayGFX& disp = *displayRef;
+#ifdef USE_TFT_ESPI
+  gfx_base& disp = display;
+#else
+  gfx_base& disp = *displayRef;
+#endif
   if (!spriteReady) {
     Serial.println("drawBitmapImage skipped - sprite not ready");
     return;

--- a/ESP32_CHAT/lvgl_ui.cpp
+++ b/ESP32_CHAT/lvgl_ui.cpp
@@ -19,12 +19,21 @@ static lv_obj_t *scr_weather;
 static lv_obj_t *scr_chat;
 
 static void flush_cb(lv_disp_drv_t *drv, const lv_area_t *area, lv_color_t *color_p) {
+#ifdef USE_TFT_ESPI
+  display.startWrite();
+  display.pushImage(area->x1, area->y1,
+                    area->x2 - area->x1 + 1,
+                    area->y2 - area->y1 + 1,
+                    (uint16_t *)color_p);
+  display.endWrite();
+#else
   display.startWrite();
   display.pushImage(area->x1, area->y1,
                     area->x2 - area->x1 + 1,
                     area->y2 - area->y1 + 1,
                     (lgfx::rgb565_t *)color_p);
   display.endWrite();
+#endif
   lv_disp_flush_ready(drv);
 }
 

--- a/README.md
+++ b/README.md
@@ -163,12 +163,10 @@ extend the codebase with additional hardware like a microphone or
 speaker.
 
 This release now includes a minimal [LVGL](https://github.com/lvgl/lvgl)
-setup (`lvgl_ui.*`) wired to the existing LovyanGFX display and touch
-drivers. **LovyanGFX v1** is required and the code defines
-`LGFX_USE_V1` automatically. Make sure the
-[LovyanGFX](https://github.com/lovyan03/LovyanGFX) library version 1.2 or
-newer is installed in the Arduino IDE. Older releases lack the
-`Bus_SPI` and `Panel_ILI9488` APIs used by the custom display driver.
+setup (`lvgl_ui.*`) wired to the TFT_eSPI display library by default.
+If desired the previous LovyanGFX based driver can still be enabled by
+undefining `USE_TFT_ESPI` in `display.h`. When using TFT_eSPI be sure to
+configure the `User_Setup.h` file with the Makerfabs ILI9488 pinout.
 LVGL allows creation of modern widgets such
 as labels and buttons and greatly simplifies building polished user
 interfaces. The


### PR DESCRIPTION
## Summary
- add optional TFT_eSPI driver and enable it by default
- update `initDisplay` to work with TFT_eSPI sprites
- adapt LVGL flush callback for TFT_eSPI
- update README to explain new default driver

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6869c4ca58c08321b7a879209f250439