### PR TITLE
Fix LVGL icon symbols clash

### DIFF
--- a/ESP32_CHAT/lvgl_ui.cpp
+++ b/ESP32_CHAT/lvgl_ui.cpp
@@ -2,8 +2,11 @@
 #include "display.h"
 #include "weather.h"
 #include "weather_icons.h"
-#include "icon_sun.c"
-#include "icon_rain.c"
+
+extern "C" {
+extern const lv_img_dsc_t icon_sun;
+extern const lv_img_dsc_t icon_rain;
+}
 
 namespace lvgl_ui {
 static bool ready = false;
@@ -29,9 +32,6 @@ static void create_header(lv_obj_t *parent);
 static void create_temperature_section(lv_obj_t *parent);
 static void create_minmax_section(lv_obj_t *parent);
 static void create_footer(lv_obj_t *parent);
-
-extern const lv_img_dsc_t icon_sun;
-extern const lv_img_dsc_t icon_rain;
 
 static void flush_cb(lv_disp_drv_t *disp, const lv_area_t *area, lv_color_t *color_p) {
   uint32_t w = area->x2 - area->x1 + 1;


### PR DESCRIPTION
## Summary
- remove duplicate inclusion of icon images
- declare icons as C symbols to avoid name mangling

## Testing
- `arduino-cli compile -b esp32:esp32:esp32 ESP32_CHAT/ESP32_CHAT.ino` *(fails: platform not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686a3aa0255483218ca98eca0c4c96e1