### PR TITLE
Keep widgets under ui folder

### DIFF
--- a/ESP32_CHAT/GuiService.cpp
+++ b/ESP32_CHAT/GuiService.cpp
@@ -1,6 +1,6 @@
-#include "GuiService.h"
-#include "../display.h"
-#include "../touch.h"
+#include "ui/GuiService.h"
+#include "display.h"
+#include "touch.h"
 
 namespace ui {
 


### PR DESCRIPTION
## Summary
- move `ChatWidget.cpp` and `WeatherWidget.cpp` back into `ui` folder
- fix include paths after moving the widget source files

This keeps the UI widgets grouped together while still compiling `GuiService.cpp` from the sketch root.

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686ab398315483218956280ee2fd7d62