### PR TITLE
Fix widget namespace conflicts

### DIFF
--- a/ESP32_CHAT/GuiService.h
+++ b/ESP32_CHAT/GuiService.h
@@ -1,8 +1,8 @@
 #pragma once
 #include <lvgl.h>
 #include <Arduino.h>
-#include "UI/WeatherWidget.h"
-#include "UI/ChatWidget.h"
+#include "ui/WeatherWidget.h"
+#include "ui/ChatWidget.h"
 
 namespace UI {
 

--- a/ESP32_CHAT/ui/ChatWidget.cpp
+++ b/ESP32_CHAT/ui/ChatWidget.cpp
@@ -1,6 +1,6 @@
 #include "ChatWidget.h"
 
-namespace ui {
+namespace UI {
 
 ChatWidget::ChatWidget() {}
 
@@ -22,4 +22,4 @@ void ChatWidget::setText(const String &text) {
     lv_label_set_text(label, text.c_str());
 }
 
-} // namespace ui
+} // namespace UI

--- a/ESP32_CHAT/ui/ChatWidget.h
+++ b/ESP32_CHAT/ui/ChatWidget.h
@@ -2,7 +2,7 @@
 #include <lvgl.h>
 #include <Arduino.h>
 
-namespace ui {
+namespace UI {
 
 class ChatWidget {
 public:
@@ -15,4 +15,4 @@ private:
     lv_obj_t* label = nullptr;
 };
 
-} // namespace ui
+} // namespace UI

--- a/ESP32_CHAT/ui/WeatherWidget.cpp
+++ b/ESP32_CHAT/ui/WeatherWidget.cpp
@@ -6,7 +6,7 @@ extern const lv_img_dsc_t icon_sun;
 extern const lv_img_dsc_t icon_rain;
 }
 
-namespace ui {
+namespace UI {
 
 WeatherWidget::WeatherWidget() {}
 
@@ -90,4 +90,4 @@ void WeatherWidget::update(float tempC, float tempMin, float tempMax, bool isRai
     lv_bar_set_value(progressBar, (int)(progress * 100), LV_ANIM_OFF);
 }
 
-} // namespace ui
+} // namespace UI

--- a/ESP32_CHAT/ui/WeatherWidget.h
+++ b/ESP32_CHAT/ui/WeatherWidget.h
@@ -2,7 +2,7 @@
 #include <lvgl.h>
 #include <Arduino.h>
 
-namespace ui {
+namespace UI {
 
 class WeatherWidget {
 public:
@@ -20,4 +20,4 @@ private:
     lv_obj_t* progressBar = nullptr;
 };
 
-} // namespace ui
+} // namespace UI


### PR DESCRIPTION
## Summary
- correct include paths for `ChatWidget` and `WeatherWidget`
- rename widget namespaces from `ui` to `UI`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686abdaf8b58832181428ca3dbca6cf2