### PR TITLE
Fix widget namespace mismatch

### DIFF
--- a/ESP32_CHAT/GuiService.cpp
+++ b/ESP32_CHAT/GuiService.cpp
@@ -4,8 +4,8 @@
 
 namespace UI {
 
-static WeatherWidget weatherWidget;
-static ChatWidget chatWidget;
+static ui::WeatherWidget weatherWidget;
+static ui::ChatWidget chatWidget;
 static bool ready = false;
 static lv_disp_draw_buf_t draw_buf;
 static lv_color_t *buf1 = nullptr;
@@ -94,7 +94,7 @@ void showChat(const String &text) {
     lv_scr_load(scr_chat);
 }
 
-WeatherWidget& weather() { return weatherWidget; }
-ChatWidget& chat() { return chatWidget; }
+ui::WeatherWidget& weather() { return weatherWidget; }
+ui::ChatWidget& chat() { return chatWidget; }
 
 } // namespace UI

--- a/ESP32_CHAT/GuiService.h
+++ b/ESP32_CHAT/GuiService.h
@@ -1,8 +1,8 @@
 #pragma once
 #include <lvgl.h>
 #include <Arduino.h>
-#include "UI/WeatherWidget.h"
-#include "UI/ChatWidget.h"
+#include "ui/WeatherWidget.h"
+#include "ui/ChatWidget.h"
 
 namespace UI {
 
@@ -11,7 +11,7 @@ void loop();
 void updateWeather(float t, float tMin, float tMax, bool isRain, float progress, const String &location);
 void showChat(const String &text);
 
-WeatherWidget& weather();
-ChatWidget& chat();
+ui::WeatherWidget& weather();
+ui::ChatWidget& chat();
 
 } // namespace UI


### PR DESCRIPTION
## Summary
- include widget headers from the `ui` folder
- reference `ui::WeatherWidget` and `ui::ChatWidget` within `UI` namespace

## Testing
- `g++ -std=c++17 -I ESP32_CHAT -c ESP32_CHAT/GuiService.cpp` *(fails: lvgl.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_686abdaf8b58832181428ca3dbca6cf2