### PR TITLE
Fix namespace case for UI widgets

### DIFF
--- a/ESP32_CHAT/GuiService.cpp
+++ b/ESP32_CHAT/GuiService.cpp
@@ -4,8 +4,8 @@
 
 namespace UI {
 
-static ui::WeatherWidget weatherWidget;
-static ui::ChatWidget chatWidget;
+static UI::WeatherWidget weatherWidget;
+static UI::ChatWidget chatWidget;
 static bool ready = false;
 static lv_disp_draw_buf_t draw_buf;
 static lv_color_t *buf1 = nullptr;
@@ -94,7 +94,7 @@ void showChat(const String &text) {
     lv_scr_load(scr_chat);
 }
 
-ui::WeatherWidget& weather() { return weatherWidget; }
-ui::ChatWidget& chat() { return chatWidget; }
+UI::WeatherWidget& weather() { return weatherWidget; }
+UI::ChatWidget& chat() { return chatWidget; }
 
 } // namespace UI

--- a/ESP32_CHAT/GuiService.h
+++ b/ESP32_CHAT/GuiService.h
@@ -1,8 +1,8 @@
 #pragma once
 #include <lvgl.h>
 #include <Arduino.h>
-#include "UI/WeatherWidget.h"
-#include "UI/ChatWidget.h"
+#include "ui/WeatherWidget.h"
+#include "ui/ChatWidget.h"
 
 namespace UI {
 
@@ -11,7 +11,7 @@ void loop();
 void updateWeather(float t, float tMin, float tMax, bool isRain, float progress, const String &location);
 void showChat(const String &text);
 
-ui::WeatherWidget& weather();
-ui::ChatWidget& chat();
+UI::WeatherWidget& weather();
+UI::ChatWidget& chat();
 
 } // namespace UI

--- a/ESP32_CHAT/app.cpp
+++ b/ESP32_CHAT/app.cpp
@@ -18,8 +18,8 @@ void begin() {
   Serial.println("app: initDisplay");
   initDisplay();
 #if !DEBUG_MODE
-  Serial.println("app: ui::begin");
-  if (!ui::begin()) {
+  Serial.println("app: UI::begin");
+  if (!UI::begin()) {
     Serial.println("LVGL UI disabled due to init failure");
   }
   Serial.println("app: initAudio");
@@ -47,12 +47,12 @@ void loop() {
 #if !DEBUG_MODE
   processTouch();
   processSerial();
-  ui::loop();
+  UI::loop();
 
   if (state.page == Page::ChatGpt) {
     if (isTyping()) {
       drawChatGptScreen();
-  ui::showChat(getChatGptPartialResponse());
+  UI::showChat(getChatGptPartialResponse());
     }
   } else {
     handleWeatherUpdate(state.tempC, state.tempMin, state.tempMax,

--- a/ESP32_CHAT/weather.ino
+++ b/ESP32_CHAT/weather.ino
@@ -91,5 +91,5 @@ void handleWeatherUpdate(float &tempC, float &tempMin, float &tempMax, uint8_t &
   }
 
   drawWeatherScreen(tempC, tempMin, tempMax, isRain, progress);
-  ui::updateWeather(tempC, tempMin, tempMax, isRain, progress, LOCATION_NAME);
+  UI::updateWeather(tempC, tempMin, tempMax, isRain, progress, LOCATION_NAME);
 }


### PR DESCRIPTION
## Summary
- fix inconsistent namespace usage for GUI widgets

## Testing
- `arduino-cli version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686acbda72608321a3d45b740cbad2f8