### PR TITLE
Fix LVGL v8 compatibility

### DIFF
--- a/ESP32_CHAT/ui/ChatWidget.cpp
+++ b/ESP32_CHAT/ui/ChatWidget.cpp
@@ -3,7 +3,7 @@
 
 namespace UI {
 
-static void anim_x_cb(void * var, int32_t v)
+static void anim_x_chat_cb(void * var, int32_t v)
 {
     lv_obj_set_x((lv_obj_t *) var, v);
 }
@@ -11,8 +11,8 @@ static void anim_x_cb(void * var, int32_t v)
 ChatWidget::ChatWidget() {}
 
 lv_obj_t* ChatWidget::create(lv_obj_t* parent) {
-    static int32_t col_dsc[] = {LV_GRID_FR(1), LV_GRID_TEMPLATE_LAST};
-    static int32_t row_dsc[] = {LV_GRID_CONTENT, LV_GRID_TEMPLATE_LAST};
+    static lv_coord_t col_dsc[] = {LV_GRID_FR(1), LV_GRID_TEMPLATE_LAST};
+    static lv_coord_t row_dsc[] = {LV_GRID_CONTENT, LV_GRID_TEMPLATE_LAST};
 
     container = lv_obj_create(parent);
     lv_obj_set_size(container, LV_PCT(100), LV_PCT(100));
@@ -39,8 +39,8 @@ void ChatWidget::setText(const String &text) {
     lv_anim_init(&a);
     lv_anim_set_var(&a, label);
     lv_anim_set_values(&a, -lv_obj_get_width(label), 0);
-    lv_anim_set_duration(&a, 500);
-    lv_anim_set_exec_cb(&a, anim_x_cb);
+    lv_anim_set_time(&a, 500);
+    lv_anim_set_exec_cb(&a, anim_x_chat_cb);
     lv_anim_set_path_cb(&a, lv_anim_path_overshoot);
     lv_anim_start(&a);
 }

--- a/ESP32_CHAT/ui/GuiTheme.cpp
+++ b/ESP32_CHAT/ui/GuiTheme.cpp
@@ -1,22 +1,26 @@
 #include "GuiTheme.h"
 #include "../weather_icons.h"
+#include <string.h>
 
 namespace UI {
 
 lv_style_t widgetStyle;
 lv_font_t *emojiFont = nullptr;
 
-static const void * emoji_path_cb(const lv_font_t * font, uint32_t unicode, uint32_t unicode_next,
-                                  int32_t * offset_y, void * user_data)
+static bool emoji_path_cb(const lv_font_t * font, void * img_src, uint16_t len,
+                          uint32_t unicode, uint32_t unicode_next)
 {
     LV_UNUSED(font);
     LV_UNUSED(unicode_next);
-    LV_UNUSED(offset_y);
-    LV_UNUSED(user_data);
 
-    if(unicode == 0xF617) return &icon_sun;
-    if(unicode == 0xF600) return &icon_rain;
-    return NULL;
+    if(len < sizeof(lv_img_dsc_t *)) return false;
+    const lv_img_dsc_t *img = NULL;
+    if(unicode == 0xF617) img = &icon_sun;
+    else if(unicode == 0xF600) img = &icon_rain;
+    else return false;
+
+    memcpy(img_src, &img, sizeof(img));
+    return true;
 }
 
 void initTheme()
@@ -33,7 +37,7 @@ void initTheme()
     lv_style_set_text_line_space(&widgetStyle, 20);
     lv_style_set_text_decor(&widgetStyle, LV_TEXT_DECOR_UNDERLINE);
 
-    emojiFont = lv_imgfont_create(32, emoji_path_cb, NULL);
+    emojiFont = lv_imgfont_create(32, emoji_path_cb);
     if(emojiFont) emojiFont->fallback = LV_FONT_DEFAULT;
 }
 

--- a/ESP32_CHAT/ui/WeatherWidget.cpp
+++ b/ESP32_CHAT/ui/WeatherWidget.cpp
@@ -4,7 +4,7 @@
 
 namespace UI {
 
-static void anim_x_cb(void * var, int32_t v)
+static void anim_x_weather_cb(void * var, int32_t v)
 {
     lv_obj_set_x((lv_obj_t *) var, v);
 }
@@ -12,8 +12,8 @@ static void anim_x_cb(void * var, int32_t v)
 WeatherWidget::WeatherWidget() {}
 
 lv_obj_t* WeatherWidget::create(lv_obj_t* parent) {
-    static int32_t col_dsc[] = {LV_GRID_FR(1), LV_GRID_FR(1), LV_GRID_FR(1), LV_GRID_TEMPLATE_LAST};
-    static int32_t row_dsc[] = {LV_GRID_CONTENT, LV_GRID_CONTENT, LV_GRID_CONTENT, LV_GRID_CONTENT, LV_GRID_TEMPLATE_LAST};
+    static lv_coord_t col_dsc[] = {LV_GRID_FR(1), LV_GRID_FR(1), LV_GRID_FR(1), LV_GRID_TEMPLATE_LAST};
+    static lv_coord_t row_dsc[] = {LV_GRID_CONTENT, LV_GRID_CONTENT, LV_GRID_CONTENT, LV_GRID_CONTENT, LV_GRID_TEMPLATE_LAST};
 
     container = lv_obj_create(parent);
     lv_obj_remove_style_all(container);
@@ -84,8 +84,8 @@ void WeatherWidget::update(float tempC, float tempMin, float tempMax, bool isRai
     lv_anim_init(&a);
     lv_anim_set_var(&a, labelTemp);
     lv_anim_set_values(&a, -lv_obj_get_width(labelTemp), 0);
-    lv_anim_set_duration(&a, 500);
-    lv_anim_set_exec_cb(&a, anim_x_cb);
+    lv_anim_set_time(&a, 500);
+    lv_anim_set_exec_cb(&a, anim_x_weather_cb);
     lv_anim_set_path_cb(&a, lv_anim_path_overshoot);
     lv_anim_start(&a);
 }


### PR DESCRIPTION
## Summary
- update grid descriptor types to `lv_coord_t`
- replace deprecated `lv_anim_set_duration` with `lv_anim_set_time`
- avoid symbol clashes by using unique callback names
- adapt imgfont path callback to LVGL v8 API

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686ae43417548321ac20f8ac8fe2a23e