### PR TITLE
Fix const mismatch for emojiFont

### DIFF
--- a/ESP32_CHAT/ui/GuiTheme.cpp
+++ b/ESP32_CHAT/ui/GuiTheme.cpp
@@ -8,7 +8,7 @@ lv_style_t styleMenuBar;
 lv_style_t styleBtnVista;
 lv_style_t styleBtnVistaPressed;
 lv_style_t widgetStyle;
-lv_font_t *emojiFont = nullptr;
+const lv_font_t *emojiFont = nullptr;
 
 void initTheme()
 {

--- a/ESP32_CHAT/ui/GuiTheme.h
+++ b/ESP32_CHAT/ui/GuiTheme.h
@@ -8,7 +8,7 @@ extern lv_style_t styleMenuBar;
 extern lv_style_t styleBtnVista;
 extern lv_style_t styleBtnVistaPressed;
 extern lv_style_t widgetStyle;    // Legacy, keep for widget usage
-extern lv_font_t *emojiFont;
+extern const lv_font_t *emojiFont;
 
 void initTheme();
 


### PR DESCRIPTION
## Summary
- use a const `lv_font_t*` for `emojiFont`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686af5751c308321b62200b17b851e4f