### PR TITLE
Remove unsupported designated initializers

### DIFF
--- a/ESP32_CHAT/assets/img_hand.c
+++ b/ESP32_CHAT/assets/img_hand.c
@@ -23,13 +23,9 @@ const LV_ATTRIBUTE_MEM_ALIGN LV_ATTRIBUTE_IMAGE_IMG_HAND uint8_t img_hand_map[] 
 };
 
 const lv_img_dsc_t img_hand = {
-    .header = {
-        .cf = LV_IMG_CF_TRUE_COLOR_ALPHA,
-        .w = 100,
-        .h = 9,
-    },
-    .data_size = sizeof(img_hand_map),
-    .data = img_hand_map,
+    { LV_IMG_CF_TRUE_COLOR_ALPHA, 100, 9 },
+    sizeof(img_hand_map),
+    img_hand_map
 };
 
 #endif /* LV_BUILD_EXAMPLES */

--- a/ESP32_CHAT/assets/imgbtn_left.c
+++ b/ESP32_CHAT/assets/imgbtn_left.c
@@ -65,13 +65,9 @@ const LV_ATTRIBUTE_MEM_ALIGN LV_ATTRIBUTE_LARGE_CONST LV_ATTRIBUTE_IMAGE_IMGBTN_
 };
 
 const lv_img_dsc_t imagebutton_left = {
-    .header = {
-        .cf = LV_IMG_CF_TRUE_COLOR_ALPHA,
-        .w = 8,
-        .h = 50,
-    },
-    .data_size = sizeof(imagebutton_left_map),
-    .data = imagebutton_left_map,
+    { LV_IMG_CF_TRUE_COLOR_ALPHA, 8, 50 },
+    sizeof(imagebutton_left_map),
+    imagebutton_left_map
 };
 
 #endif /* LV_BUILD_EXAMPLES */

--- a/ESP32_CHAT/assets/imgbtn_right.c
+++ b/ESP32_CHAT/assets/imgbtn_right.c
@@ -66,13 +66,9 @@ const LV_ATTRIBUTE_MEM_ALIGN LV_ATTRIBUTE_LARGE_CONST LV_ATTRIBUTE_IMAGE_IMGBTN_
 };
 
 const lv_img_dsc_t imagebutton_right = {
-    .header = {
-        .cf = LV_IMG_CF_TRUE_COLOR_ALPHA,
-        .w = 8,
-        .h = 50,
-    },
-    .data_size = sizeof(imagebutton_right_map),
-    .data = imagebutton_right_map,
+    { LV_IMG_CF_TRUE_COLOR_ALPHA, 8, 50 },
+    sizeof(imagebutton_right_map),
+    imagebutton_right_map
 };
 
 #endif /* LV_BUILD_EXAMPLES */

--- a/ESP32_CHAT/icon_rain.c
+++ b/ESP32_CHAT/icon_rain.c
@@ -346,13 +346,7 @@ LV_ATTRIBUTE_MEM_ALIGN const uint8_t icon_rain_map[] = {
 };
 
 const lv_img_dsc_t icon_rain = {
-  .header = {
-    .cf = LV_IMG_CF_TRUE_COLOR_ALPHA,
-    .always_zero = 0,
-    .reserved = 0,
-    .w = 32,
-    .h = 32
-  },
-  .data_size = sizeof(icon_rain_map),
-  .data = icon_rain_map,
+  { LV_IMG_CF_TRUE_COLOR_ALPHA, 0, 0, 32, 32 },
+  sizeof(icon_rain_map),
+  icon_rain_map
 };

--- a/ESP32_CHAT/icon_sun.c
+++ b/ESP32_CHAT/icon_sun.c
@@ -346,13 +346,7 @@ LV_ATTRIBUTE_MEM_ALIGN const uint8_t icon_sun_map[] = {
 };
 
 const lv_img_dsc_t icon_sun = {
-  .header = {
-    .cf = LV_IMG_CF_TRUE_COLOR_ALPHA,
-    .always_zero = 0,
-    .reserved = 0,
-    .w = 32,
-    .h = 32
-  },
-  .data_size = sizeof(icon_sun_map),
-  .data = icon_sun_map,
+  { LV_IMG_CF_TRUE_COLOR_ALPHA, 0, 0, 32, 32 },
+  sizeof(icon_sun_map),
+  icon_sun_map
 };


### PR DESCRIPTION
## Summary
- remove C99 designated initializers from LVGL image assets

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686ba8da2e2c8321b128dd524b1ab551